### PR TITLE
feat: enhance middleware to handle public and admin routes

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,12 +1,38 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
 
-export default clerkMiddleware();
+const isAdminRoute = createRouteMatcher(["/admin(.*)"]);
+const isPublicRoute = createRouteMatcher([
+  "/", 
+  "/pricing(.*)",
+]);
+
+export default clerkMiddleware(async (auth, req) => {
+  // Handle public routes
+  if (isPublicRoute(req)) {
+    return NextResponse.next();
+  }
+
+  const userSession = await auth();
+
+  await auth.protect();
+
+  // Handle admin routes
+  if (isAdminRoute(req)) {
+    if (userSession?.sessionClaims?.metadata?.role !== "admin") {
+      const url = new URL("/", req.url);
+      return NextResponse.redirect(url);
+    }
+  }
+
+  return NextResponse.next();
+});
 
 export const config = {
   matcher: [
     // Skip Next.js internals and all static files, unless found in search params
-    '/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    "/((?!_next|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)",
     // Always run for API routes
-    '/(api|trpc)(.*)',
+    "/(api|trpc)(.*)",
   ],
 };


### PR DESCRIPTION
This PR implements role-based access control (RBAC) using Clerk's middleware for route protection in the Next.js app. Public routes are accessible to all users, while admin routes and other protected routes require authentication.

### Changes:
- Added `clerkMiddleware` to manage authentication and role-based access.
- Protected all routes except public ones (`/` and `/pricing`), ensuring users must be authenticated to access them.
- Restricted `/admin` routes to users with the role of "admin."
- Configured route matching for Next.js internals and static files to ensure proper routing behavior.

### Protection Rules:
- **Public Routes:** `"/"`, `"/pricing(.*)"` (accessible without authentication).
- **Protected Routes:** All other routes are protected and require user authentication.
- **Admin Routes:** Only accessible to users with the "admin" role.

For more details on Clerk's RBAC implementation, refer to [[Clerk RBAC Documentation](https://clerk.com/docs/references/nextjs/basic-rbac)](https://clerk.com/docs/references/nextjs/basic-rbac).

